### PR TITLE
Feature/project refresh

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,9 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - 'feature/**'
+      - 'bugfix/**'
   pull_request:
 jobs:
   restore-build-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           path: ./TestResults
         if: ${{ always() }}
       - name: Pack NuGet package
-        run: dotnet pack ./src/Sitemapr/Sitemapr.csproj -c Release --no-build -o ./output/ -p:Version=$RELEASE_VERSION
+        run: dotnet pack -c Release --no-build -o ./output/ -p:Version=$RELEASE_VERSION
       - name: Push Nuget package
         run: dotnet nuget push ./output/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/src/Sitemapr/Sitemapr.csproj
+++ b/src/Sitemapr/Sitemapr.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
-        <Authors>Sitemapr Contributors, Michel Gammelgaard</Authors>
+        <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <Title>Sitemapr</Title>
+        <Description>Sitemapr Contributors, Michel Gammelgaard</Description>
+        <Authors>CrawlCtrl Contributors, Michel Gammelgaard</Authors>
         <Company>Acidus</Company>
-        <Description>Dependency injection extensions for Sitemapr</Description>
+        <Copyright>Copyright (c) Acidus 2024</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>crawling;sitemap</PackageTags>
-        <Title>Sitemapr</Title>
-        <Copyright>Copyright (c) Acidus 2023</Copyright>
         <PackageProjectUrl>https://github.com/Sitemapr/Sitemapr</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/Sitemapr/Sitemapr</RepositoryUrl>

--- a/test/Sitemapr.UnitTests/Sitemapr.UnitTests.csproj
+++ b/test/Sitemapr.UnitTests/Sitemapr.UnitTests.csproj
@@ -4,11 +4,12 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <WarningsAsErrors>Nullable</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-      <PackageReference Include="xunit" Version="2.6.4" />
+      <PackageReference Include="xunit" Version="2.6.6" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updated the NuGet information in the Sitemapr csproj file.

Replaced targeting of .NET 4.6.1 with 4.6.2 in NuGet projects per recommendation from Microsoft: https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting

Updated Github workflows to align them with the workflows used in the CrawlCtrl project.